### PR TITLE
add column number to sample config file

### DIFF
--- a/sample_data/config.json
+++ b/sample_data/config.json
@@ -1,34 +1,42 @@
 {
     "columnLens": [
         {
+            "column": 0,
             "start": 0,
             "end": 7
         },
         {
+            "column": 1,            
             "start": 7,
             "end": 22
         },
         {
+            "column": 2,            
             "start": 22,
             "end": 39
         },
         {
+            "column": 3,
             "start": 39,
             "end": 64
         },
         {
+            "column": 4,
             "start": 64,
             "end": 102
         },
         {
+            "column": 5,
             "start": 102,
             "end": 137
         },
         {
+            "column": 6,
             "start": 137,
             "end": 150
         },
         {
+            "column": 7,
             "start": 150,
             "end": 164
         }


### PR DESCRIPTION
column number added to config file.  However (for now) this is ignored and the column numbers are interpreted by the order in which they appear in the file.